### PR TITLE
Add sweeping methods

### DIFF
--- a/include/cell.h
+++ b/include/cell.h
@@ -10,6 +10,20 @@ class Cell {
   Cell(const double xmin, const double xmax, const double ymin,
        const double ymax, const Material& material);
 
+  double cell_source() const { return cell_source_; }
+  double west_flux() const { return west_flux_; }
+  double north_flux() const { return north_flux_; }
+  double south_flux() const { return south_flux_; }
+  double east_flux() const { return east_flux_; }
+  double dx() const { return dx_; }
+  double dy() const { return dy_; }
+  Material material() const { return material_; }
+
+  void SetEastFlux() { east_flux_ = 2 * center_flux_ - west_flux_; }
+  void SetWestFlux() { west_flux_ = 2 * center_flux_ - east_flux_; }
+  void SetNorthFlux() { north_flux_ = 2 * center_flux_ - south_flux_; }
+  void SetSouthFlux() { south_flux_ = 2 * center_flux_ - north_flux_; }
+
  private:
   const Point cell_center_;
   const double xmin_;
@@ -21,6 +35,15 @@ class Cell {
   const Material& material_;
 
   Point ComputeCellCenter();
+
+  double west_flux_ = 0;
+  double north_flux_ = 0;
+  double south_flux_ = 0;
+  double east_flux_ = 0;
+  double center_flux_ = 0;
+  double cell_source_ = 0;
+
+  void SetCellSource(const double cell_scalar_flux);
 };
 }  // namespace ar
 

--- a/include/cell.h
+++ b/include/cell.h
@@ -23,6 +23,7 @@ class Cell {
   void SetWestFlux() { west_flux_ = 2 * center_flux_ - east_flux_; }
   void SetNorthFlux() { north_flux_ = 2 * center_flux_ - south_flux_; }
   void SetSouthFlux() { south_flux_ = 2 * center_flux_ - north_flux_; }
+  void SetCenterFlux(const double center_flux) { center_flux_ = center_flux; }
 
  private:
   const Point cell_center_;

--- a/include/simulation.h
+++ b/include/simulation.h
@@ -58,18 +58,6 @@ class Simulation {
       const double y_cosine);
 
   /**
-   * @brief Evaluate the cell-centered angular flux moving in direction
-   * northeast
-   *
-   * @param x_cosine
-   * @param y_cosine
-   * @param cell
-   * @return double
-   */
-  double NorthEastSweepStep(const double x_cosine, const double y_cosine,
-                            Cell& cell);
-
-  /**
    * @brief Carries out transport sweep from Southwest corner to Northeast.
    * Returns a 2D vector of SCALAR flux contributions by multiplying the
    * cell-centered angular flux by the quadrature weight
@@ -82,18 +70,6 @@ class Simulation {
   std::vector<std::vector<double>> SweepNorthWest(
       const double quadrature_weight, const double x_cosine,
       const double y_cosine);
-
-  /**
-   * @brief Evaluate the cell-centered angular flux moving in direction
-   * northwest
-   *
-   * @param x_cosine
-   * @param y_cosine
-   * @param cell
-   * @return double
-   */
-  double NorthWestSweepStep(const double x_cosine, const double y_cosine,
-                            Cell& cell);
 
   /**
    * @brief Carries out transport sweep from Northwest corner to Southeast.
@@ -110,18 +86,6 @@ class Simulation {
       const double y_cosine);
 
   /**
-   * @brief Evaluate the cell-centered angular flux moving in direction
-   * southeast
-   *
-   * @param x_cosine
-   * @param y_cosine
-   * @param cell
-   * @return double
-   */
-  double SouthEastSweepStep(const double x_cosine, const double y_cosine,
-                            Cell& cell);
-
-  /**
    * @brief Carries out transport sweep from Northeast corner to Southwest.
    * Returns a 2D vector of SCALAR flux contributions by multiplying the
    * cell-centered angular flux by the quadrature weight
@@ -136,17 +100,14 @@ class Simulation {
       const double y_cosine);
 
   /**
-   * @brief Evaluate the cell-centered angular flux moving in direction
-   * southwest
+   * @brief Evaluates the cell-centered angular flux for a single cell
    *
    * @param x_cosine
    * @param y_cosine
    * @param cell
    * @return double
    */
-  double SouthWestSweepStep(const double x_cosine, const double y_cosine,
-                            Cell& cell);
-
+  double SweepStep(const double x_cosine, const double y_cosine, Cell& cell);
   /**
    * @brief Exports results to a CSV output file for postprocessing
    *

--- a/include/simulation.h
+++ b/include/simulation.h
@@ -58,7 +58,7 @@ class Simulation {
       const double y_cosine);
 
   /**
-   * @brief Carries out transport sweep from Southwest corner to Northeast.
+   * @brief Carries out transport sweep from Southeast corner to Northwest.
    * Returns a 2D vector of SCALAR flux contributions by multiplying the
    * cell-centered angular flux by the quadrature weight
    *

--- a/include/simulation.h
+++ b/include/simulation.h
@@ -44,6 +44,110 @@ class Simulation {
       const std::vector<Cell>& flattened_cells);
 
   /**
+   * @brief Carries out transport sweep from Southwest corner to Northeast.
+   * Returns a 2D vector of SCALAR flux contributions by multiplying the
+   * cell-centered angular flux by the quadrature weight
+   *
+   * @param quadrature_weight
+   * @param x_cosine
+   * @param y_cosine
+   * @return std::vector<std::vector<double>>
+   */
+  std::vector<std::vector<double>> SweepNorthEast(
+      const double quadrature_weight, const double x_cosine,
+      const double y_cosine);
+
+  /**
+   * @brief Evaluate the cell-centered angular flux moving in direction
+   * northeast
+   *
+   * @param x_cosine
+   * @param y_cosine
+   * @param cell
+   * @return double
+   */
+  double NorthEastSweepStep(const double x_cosine, const double y_cosine,
+                            Cell& cell);
+
+  /**
+   * @brief Carries out transport sweep from Southwest corner to Northeast.
+   * Returns a 2D vector of SCALAR flux contributions by multiplying the
+   * cell-centered angular flux by the quadrature weight
+   *
+   * @param quadrature_weight
+   * @param x_cosine
+   * @param y_cosine
+   * @return std::vector<std::vector<double>>
+   */
+  std::vector<std::vector<double>> SweepNorthWest(
+      const double quadrature_weight, const double x_cosine,
+      const double y_cosine);
+
+  /**
+   * @brief Evaluate the cell-centered angular flux moving in direction
+   * northwest
+   *
+   * @param x_cosine
+   * @param y_cosine
+   * @param cell
+   * @return double
+   */
+  double NorthWestSweepStep(const double x_cosine, const double y_cosine,
+                            Cell& cell);
+
+  /**
+   * @brief Carries out transport sweep from Northwest corner to Southeast.
+   * Returns a 2D vector of SCALAR flux contributions by multiplying the
+   * cell-centered angular flux by the quadrature weight
+   *
+   * @param quadrature_weight
+   * @param x_cosine
+   * @param y_cosine
+   * @return std::vector<std::vector<double>>
+   */
+  std::vector<std::vector<double>> SweepSouthEast(
+      const double quadrature_weight, const double x_cosine,
+      const double y_cosine);
+
+  /**
+   * @brief Evaluate the cell-centered angular flux moving in direction
+   * southeast
+   *
+   * @param x_cosine
+   * @param y_cosine
+   * @param cell
+   * @return double
+   */
+  double SouthEastSweepStep(const double x_cosine, const double y_cosine,
+                            Cell& cell);
+
+  /**
+   * @brief Carries out transport sweep from Northeast corner to Southwest.
+   * Returns a 2D vector of SCALAR flux contributions by multiplying the
+   * cell-centered angular flux by the quadrature weight
+   *
+   * @param quadrature_weight
+   * @param x_cosine
+   * @param y_cosine
+   * @return std::vector<std::vector<double>>
+   */
+  std::vector<std::vector<double>> SweepSouthWest(
+      const double quadrature_weight, const double x_cosine,
+      const double y_cosine);
+
+  /**
+   * @brief Evaluate the cell-centered angular flux moving in direction
+   * southwest
+   *
+   * @param x_cosine
+   * @param y_cosine
+   * @param cell
+   * @return double
+   */
+  double SouthWestSweepStep(const double x_cosine, const double y_cosine,
+                            Cell& cell);
+
+  /**
    * @brief Exports results to a CSV output file for postprocessing
    *
    */

--- a/include/simulation.h
+++ b/include/simulation.h
@@ -43,6 +43,9 @@ class Simulation {
   std::vector<std::vector<Cell>> SortCells(
       const std::vector<Cell>& flattened_cells);
 
+  int n_columns_;  /// Number of columns in 2D vector of cells
+  int n_rows_;     /// Number of rows in 2D vector of cells
+
   /**
    * @brief Carries out transport sweep from Southwest corner to Northeast.
    * Returns a 2D vector of SCALAR flux contributions by multiplying the

--- a/src/cell.cc
+++ b/src/cell.cc
@@ -10,11 +10,18 @@ Cell::Cell(const double xmin, const double xmax, const double ymin,
       material_(material),
       dx_(xmax - xmin),
       dy_(ymax - ymin),
-      cell_center_(ComputeCellCenter()) {}
+      cell_center_(ComputeCellCenter()) {
+  cell_source_ = material_.IsotropicSource();  // initialize source value
+}
 
 Point Cell::ComputeCellCenter() {
   double x_coord = xmin_ + dx_ / 2.0;
   double y_coord = ymin_ + dy_ / 2.0;
   return Point(x_coord, y_coord);
+}
+
+void Cell::SetCellSource(const double cell_scalar_flux) {
+  cell_source_ = material_.scattering_xs() * cell_scalar_flux +
+                 material_.IsotropicSource();  // check this!!!
 }
 }  // namespace ar

--- a/src/simulation.cc
+++ b/src/simulation.cc
@@ -41,6 +41,27 @@ std::vector<std::vector<double>> Simulation::SweepNorthEast(
   return scalar_flux_contribution;
 }
 
+std::vector<std::vector<double>> Simulation::SweepNorthWest(
+    const double quadrature_weight, const double x_cosine,
+    const double y_cosine) {
+  int n_cols = cells_[0].size();
+  int n_rows = cells_.size();
+
+  std::vector<std::vector<double>> scalar_flux_contribution(
+      n_rows, std::vector<double>(n_cols, 0.0));  // preallocates to all zeros
+
+  for (auto j = 0; j < n_rows; j++) {
+    for (auto i = n_cols - 1; i > -1; i--) {
+      double cell_center_flux = SweepStep(x_cosine, y_cosine, cells_[i][j]);
+      scalar_flux_contribution[i][j] += cell_center_flux * quadrature_weight;
+      cells_[i][j].SetCenterFlux(cell_center_flux);
+      cells_[i][j].SetWestFlux();
+      cells_[i][j].SetNorthFlux();
+    }
+  }
+  return scalar_flux_contribution;
+}
+
 double Simulation::SweepStep(const double x_cosine, const double y_cosine,
                              Cell &cell) {
   double east_west_flux = cell.west_flux();

--- a/src/simulation.cc
+++ b/src/simulation.cc
@@ -21,10 +21,26 @@ std::vector<std::vector<Cell>> Simulation::SortCells(
 
 double Simulation::NorthEastSweepStep(const double x_cosine,
                                       const double y_cosine, Cell &cell) {
+  double x_sign = x_cosine > 0 ? 1.0 : -1.0;
+  double y_sign = y_cosine > 0 ? 1.0 : -1.0;
   double numerator = cell.cell_source() +
-                     2.0 * x_cosine / cell.dx() * cell.west_flux() +
-                     2.0 * y_cosine / cell.dy() * cell.south_flux();
-  double denominator = 2.0 * x_cosine / cell.dx() + 2.0 * y_cosine / cell.dy() +
+                     x_sign * 2.0 * x_cosine / cell.dx() * cell.west_flux() +
+                     y_sign * 2.0 * y_cosine / cell.dy() * cell.south_flux();
+  double denominator = x_sign * 2.0 * x_cosine / cell.dx() +
+                       y_sign * 2.0 * y_cosine / cell.dy() +
+                       cell.material().total_xs();
+  return numerator / denominator;
+}
+
+double Simulation::NorthWestSweepStep(const double x_cosine,
+                                      const double y_cosine, Cell &cell) {
+  double x_sign = x_cosine > 0 ? 1.0 : -1.0;
+  double y_sign = y_cosine > 0 ? 1.0 : -1.0;
+  double numerator = cell.cell_source() +
+                     x_sign * 2.0 * x_cosine / cell.dx() * cell.east_flux() +
+                     y_sign * 2.0 * y_cosine / cell.dy() * cell.south_flux();
+  double denominator = x_sign * 2.0 * x_cosine / cell.dx() +
+                       y_sign * 2.0 * y_cosine / cell.dy() +
                        cell.material().total_xs();
   return numerator / denominator;
 }

--- a/src/simulation.cc
+++ b/src/simulation.cc
@@ -1,5 +1,7 @@
 #include "simulation.h"
 
+#include <cmath>
+
 namespace ar {
 Simulation::Simulation(const std::vector<RectangularRegion> &regions,
                        const double si_tolerance)
@@ -19,29 +21,21 @@ std::vector<Cell> Simulation::PullCellsFromRegions() {
 std::vector<std::vector<Cell>> Simulation::SortCells(
     const std::vector<Cell> &flattened_cells) {}
 
-double Simulation::NorthEastSweepStep(const double x_cosine,
-                                      const double y_cosine, Cell &cell) {
-  double x_sign = x_cosine > 0 ? 1.0 : -1.0;
-  double y_sign = y_cosine > 0 ? 1.0 : -1.0;
+double Simulation::SweepStep(const double x_cosine, const double y_cosine,
+                             Cell &cell) {
+  double east_west_flux = cell.west_flux();
+  double north_south_flux = cell.south_flux();
+  if (x_cosine < 0) east_west_flux = cell.east_flux();
+
+  if (y_cosine < 0) north_south_flux = cell.north_flux();
+
   double numerator = cell.cell_source() +
-                     x_sign * 2.0 * x_cosine / cell.dx() * cell.west_flux() +
-                     y_sign * 2.0 * y_cosine / cell.dy() * cell.south_flux();
-  double denominator = x_sign * 2.0 * x_cosine / cell.dx() +
-                       y_sign * 2.0 * y_cosine / cell.dy() +
+                     2.0 * std::abs(x_cosine) / cell.dx() * east_west_flux +
+                     2.0 * std::abs(y_cosine) / cell.dy() * north_south_flux;
+  double denominator = 2.0 * std::abs(x_cosine) / cell.dx() +
+                       2.0 * std::abs(y_cosine) / cell.dy() +
                        cell.material().total_xs();
   return numerator / denominator;
 }
 
-double Simulation::NorthWestSweepStep(const double x_cosine,
-                                      const double y_cosine, Cell &cell) {
-  double x_sign = x_cosine > 0 ? 1.0 : -1.0;
-  double y_sign = y_cosine > 0 ? 1.0 : -1.0;
-  double numerator = cell.cell_source() +
-                     x_sign * 2.0 * x_cosine / cell.dx() * cell.east_flux() +
-                     y_sign * 2.0 * y_cosine / cell.dy() * cell.south_flux();
-  double denominator = x_sign * 2.0 * x_cosine / cell.dx() +
-                       y_sign * 2.0 * y_cosine / cell.dy() +
-                       cell.material().total_xs();
-  return numerator / denominator;
-}
 }  // namespace ar

--- a/src/simulation.cc
+++ b/src/simulation.cc
@@ -18,4 +18,14 @@ std::vector<Cell> Simulation::PullCellsFromRegions() {
 
 std::vector<std::vector<Cell>> Simulation::SortCells(
     const std::vector<Cell> &flattened_cells) {}
+
+double Simulation::NorthEastSweepStep(const double x_cosine,
+                                      const double y_cosine, Cell &cell) {
+  double numerator = cell.cell_source() +
+                     2.0 * x_cosine / cell.dx() * cell.west_flux() +
+                     2.0 * y_cosine / cell.dy() * cell.south_flux();
+  double denominator = 2.0 * x_cosine / cell.dx() + 2.0 * y_cosine / cell.dy() +
+                       cell.material().total_xs();
+  return numerator / denominator;
+}
 }  // namespace ar

--- a/src/simulation.cc
+++ b/src/simulation.cc
@@ -36,6 +36,7 @@ std::vector<std::vector<double>> Simulation::SweepNorthEast(
       scalar_flux_contribution[i][j] += cell_center_flux * quadrature_weight;
       cells_[i][j].SetCenterFlux(cell_center_flux);
       cells_[i][j].SetEastFlux();
+      cells_[i][j].SetNorthFlux();
     }
   }
   return scalar_flux_contribution;

--- a/src/simulation.cc
+++ b/src/simulation.cc
@@ -8,6 +8,8 @@ Simulation::Simulation(const std::vector<RectangularRegion> &regions,
     : regions_(regions), si_tolerance_(si_tolerance) {
   std::vector<Cell> flattened_cells = PullCellsFromRegions();
   cells_ = SortCells(flattened_cells);
+  n_columns_ = cells_[0].size();
+  n_rows_ = cells_.size();
 }
 
 std::vector<Cell> Simulation::PullCellsFromRegions() {
@@ -24,14 +26,12 @@ std::vector<std::vector<Cell>> Simulation::SortCells(
 std::vector<std::vector<double>> Simulation::SweepNorthEast(
     const double quadrature_weight, const double x_cosine,
     const double y_cosine) {
-  int n_cols = cells_[0].size();
-  int n_rows = cells_.size();
-
   std::vector<std::vector<double>> scalar_flux_contribution(
-      n_rows, std::vector<double>(n_cols, 0.0));  // preallocates to all zeros
+      n_rows_,
+      std::vector<double>(n_columns_, 0.0));  // preallocates to all zeros
 
-  for (auto j = 0; j < n_rows; j++) {
-    for (auto i = 0; i < n_cols; i++) {
+  for (auto j = 0; j < n_rows_; j++) {
+    for (auto i = 0; i < n_columns_; i++) {
       double cell_center_flux = SweepStep(x_cosine, y_cosine, cells_[i][j]);
       scalar_flux_contribution[i][j] += cell_center_flux * quadrature_weight;
       cells_[i][j].SetCenterFlux(cell_center_flux);
@@ -45,14 +45,12 @@ std::vector<std::vector<double>> Simulation::SweepNorthEast(
 std::vector<std::vector<double>> Simulation::SweepNorthWest(
     const double quadrature_weight, const double x_cosine,
     const double y_cosine) {
-  int n_cols = cells_[0].size();
-  int n_rows = cells_.size();
-
   std::vector<std::vector<double>> scalar_flux_contribution(
-      n_rows, std::vector<double>(n_cols, 0.0));  // preallocates to all zeros
+      n_rows_,
+      std::vector<double>(n_columns_, 0.0));  // preallocates to all zeros
 
-  for (auto j = 0; j < n_rows; j++) {
-    for (auto i = n_cols - 1; i > -1; i--) {
+  for (auto j = 0; j < n_rows_; j++) {
+    for (auto i = n_columns_ - 1; i > -1; i--) {
       double cell_center_flux = SweepStep(x_cosine, y_cosine, cells_[i][j]);
       scalar_flux_contribution[i][j] += cell_center_flux * quadrature_weight;
       cells_[i][j].SetCenterFlux(cell_center_flux);
@@ -66,14 +64,12 @@ std::vector<std::vector<double>> Simulation::SweepNorthWest(
 std::vector<std::vector<double>> Simulation::SweepSouthEast(
     const double quadrature_weight, const double x_cosine,
     const double y_cosine) {
-  int n_cols = cells_[0].size();
-  int n_rows = cells_.size();
-
   std::vector<std::vector<double>> scalar_flux_contribution(
-      n_rows, std::vector<double>(n_cols, 0.0));  // preallocates to all zeros
+      n_rows_,
+      std::vector<double>(n_columns_, 0.0));  // preallocates to all zeros
 
-  for (auto j = n_rows - 1; j > -1; j--) {
-    for (auto i = 0; i > n_cols; i++) {
+  for (auto j = n_rows_ - 1; j > -1; j--) {
+    for (auto i = 0; i > n_columns_; i++) {
       double cell_center_flux = SweepStep(x_cosine, y_cosine, cells_[i][j]);
       scalar_flux_contribution[i][j] += cell_center_flux * quadrature_weight;
       cells_[i][j].SetCenterFlux(cell_center_flux);
@@ -87,14 +83,12 @@ std::vector<std::vector<double>> Simulation::SweepSouthEast(
 std::vector<std::vector<double>> Simulation::SweepSouthWest(
     const double quadrature_weight, const double x_cosine,
     const double y_cosine) {
-  int n_cols = cells_[0].size();
-  int n_rows = cells_.size();
-
   std::vector<std::vector<double>> scalar_flux_contribution(
-      n_rows, std::vector<double>(n_cols, 0.0));  // preallocates to all zeros
+      n_rows_,
+      std::vector<double>(n_columns_, 0.0));  // preallocates to all zeros
 
-  for (auto j = n_rows - 1; j > -1; j--) {
-    for (auto i = n_cols - 1; i > -1; i--) {
+  for (auto j = n_rows_ - 1; j > -1; j--) {
+    for (auto i = n_columns_ - 1; i > -1; i--) {
       double cell_center_flux = SweepStep(x_cosine, y_cosine, cells_[i][j]);
       scalar_flux_contribution[i][j] += cell_center_flux * quadrature_weight;
       cells_[i][j].SetCenterFlux(cell_center_flux);

--- a/src/simulation.cc
+++ b/src/simulation.cc
@@ -63,6 +63,27 @@ std::vector<std::vector<double>> Simulation::SweepNorthWest(
   return scalar_flux_contribution;
 }
 
+std::vector<std::vector<double>> Simulation::SweepSouthEast(
+    const double quadrature_weight, const double x_cosine,
+    const double y_cosine) {
+  int n_cols = cells_[0].size();
+  int n_rows = cells_.size();
+
+  std::vector<std::vector<double>> scalar_flux_contribution(
+      n_rows, std::vector<double>(n_cols, 0.0));  // preallocates to all zeros
+
+  for (auto j = n_rows - 1; j > -1; j--) {
+    for (auto i = 0; i > n_cols; i++) {
+      double cell_center_flux = SweepStep(x_cosine, y_cosine, cells_[i][j]);
+      scalar_flux_contribution[i][j] += cell_center_flux * quadrature_weight;
+      cells_[i][j].SetCenterFlux(cell_center_flux);
+      cells_[i][j].SetEastFlux();
+      cells_[i][j].SetSouthFlux();
+    }
+  }
+  return scalar_flux_contribution;
+}
+
 double Simulation::SweepStep(const double x_cosine, const double y_cosine,
                              Cell &cell) {
   double east_west_flux = cell.west_flux();

--- a/src/simulation.cc
+++ b/src/simulation.cc
@@ -84,6 +84,27 @@ std::vector<std::vector<double>> Simulation::SweepSouthEast(
   return scalar_flux_contribution;
 }
 
+std::vector<std::vector<double>> Simulation::SweepSouthWest(
+    const double quadrature_weight, const double x_cosine,
+    const double y_cosine) {
+  int n_cols = cells_[0].size();
+  int n_rows = cells_.size();
+
+  std::vector<std::vector<double>> scalar_flux_contribution(
+      n_rows, std::vector<double>(n_cols, 0.0));  // preallocates to all zeros
+
+  for (auto j = n_rows - 1; j > -1; j--) {
+    for (auto i = n_cols - 1; i > -1; i--) {
+      double cell_center_flux = SweepStep(x_cosine, y_cosine, cells_[i][j]);
+      scalar_flux_contribution[i][j] += cell_center_flux * quadrature_weight;
+      cells_[i][j].SetCenterFlux(cell_center_flux);
+      cells_[i][j].SetWestFlux();
+      cells_[i][j].SetSouthFlux();
+    }
+  }
+  return scalar_flux_contribution;
+}
+
 double Simulation::SweepStep(const double x_cosine, const double y_cosine,
                              Cell &cell) {
   double east_west_flux = cell.west_flux();

--- a/src/simulation.cc
+++ b/src/simulation.cc
@@ -21,6 +21,26 @@ std::vector<Cell> Simulation::PullCellsFromRegions() {
 std::vector<std::vector<Cell>> Simulation::SortCells(
     const std::vector<Cell> &flattened_cells) {}
 
+std::vector<std::vector<double>> Simulation::SweepNorthEast(
+    const double quadrature_weight, const double x_cosine,
+    const double y_cosine) {
+  int n_cols = cells_[0].size();
+  int n_rows = cells_.size();
+
+  std::vector<std::vector<double>> scalar_flux_contribution(
+      n_rows, std::vector<double>(n_cols, 0.0));  // preallocates to all zeros
+
+  for (auto j = 0; j < n_rows; j++) {
+    for (auto i = 0; i < n_cols; i++) {
+      double cell_center_flux = SweepStep(x_cosine, y_cosine, cells_[i][j]);
+      scalar_flux_contribution[i][j] += cell_center_flux * quadrature_weight;
+      cells_[i][j].SetCenterFlux(cell_center_flux);
+      cells_[i][j].SetEastFlux();
+    }
+  }
+  return scalar_flux_contribution;
+}
+
 double Simulation::SweepStep(const double x_cosine, const double y_cosine,
                              Cell &cell) {
   double east_west_flux = cell.west_flux();


### PR DESCRIPTION
## Summary of changes
<!--- In one or more sentences, describe the PR you are submitting. -->
Adds methods for evaluating four different sweeps:
1. Northwest
2. Northeast
3. Southwest
4. Southeast

These methods return the contribution of the angular flux to scalar flux, so only one additional array needs to be stored (as opposed to storing _all_ of the angular flux values). Flux values (both numerical flux and cell-centered angular flux) are stored in the `Cell` object and updated throughout the sweep. Tests have not yet been written.


## Associated Issues and PRs
<!--- Please note any issues or pull requests associated with this pull request. -->

- closes #2 


## Associated Developers
<!--- Please mention any developers who should be alerted of this PR. -->

- Dev: @ElijahCapps 

