### PR TITLE
Add overloated RectangularRegion constructor

### DIFF
--- a/include/rectangular_region.h
+++ b/include/rectangular_region.h
@@ -12,6 +12,9 @@ class RectangularRegion {
   RectangularRegion(const Material& material, const double xmin,
                     const double xmax, const double ymin, const double ymax,
                     const int nx, const int ny);
+  RectangularRegion(const Material& material, const double xmin,
+                    const double xmax, const double ymin, const double ymax,
+                    const double target_delta);
 
   std::vector<Cell> cells() const { return cells_; }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -20,23 +20,31 @@ int main() {
   // Code is blocked from top row to bottom row. Vacuum boundary conditions are
   // assumed for all sides.
 
-  RectangularRegion region_1(material_3, -10, 10, 5, 10, 3, 3);
+  double target_cell_width =
+      1.25;  // take multiples of this to get a grid convergence study
 
-  RectangularRegion region_2(material_3, -10, -5, 1.25, 5, 3, 3);
-  RectangularRegion region_3(material_2, -5, 5, 1.25, 5, 3, 3);
-  RectangularRegion region_4(material_3, 5, 10, 1.25, 5, 3, 3);
+  RectangularRegion region_1(material_3, -10, 10, 5, 10, target_cell_width);
 
-  RectangularRegion region_5(material_3, -10, -5, -1.25, 1.25, 3, 3);
-  RectangularRegion region_6(material_2, -5, -1.25, -1.25, 1.25, 3, 3);
-  RectangularRegion region_7(material_1, -1.25, 1.25, -1.25, 1.25, 3, 3);
-  RectangularRegion region_8(material_2, 1.25, 5, -1.25, 1.25, 3, 3);
-  RectangularRegion region_9(material_3, 5, 10, -1.25, 1.25, 3, 3);
+  RectangularRegion region_2(material_3, -10, -5, 1.25, 5, target_cell_width);
+  RectangularRegion region_3(material_2, -5, 5, 1.25, 5, target_cell_width);
+  RectangularRegion region_4(material_3, 5, 10, 1.25, 5, target_cell_width);
 
-  RectangularRegion region_10(material_3, -10, -5, -5, -1.25, 3, 3);
-  RectangularRegion region_11(material_2, -5, 5, -5, -1.25, 3, 3);
-  RectangularRegion region_12(material_3, 5, 10, -5, -1.25, 3, 3);
+  RectangularRegion region_5(material_3, -10, -5, -1.25, 1.25,
+                             target_cell_width);
+  RectangularRegion region_6(material_2, -5, -1.25, -1.25, 1.25,
+                             target_cell_width);
+  RectangularRegion region_7(material_1, -1.25, 1.25, -1.25, 1.25,
+                             target_cell_width);
+  RectangularRegion region_8(material_2, 1.25, 5, -1.25, 1.25,
+                             target_cell_width);
+  RectangularRegion region_9(material_3, 5, 10, -1.25, 1.25, target_cell_width);
 
-  RectangularRegion region_13(material_3, -10, 10, -10, -5, 3, 3);
+  RectangularRegion region_10(material_3, -10, -5, -5, -1.25,
+                              target_cell_width);
+  RectangularRegion region_11(material_2, -5, 5, -5, -1.25, target_cell_width);
+  RectangularRegion region_12(material_3, 5, 10, -5, -1.25, target_cell_width);
+
+  RectangularRegion region_13(material_3, -10, 10, -10, -5, target_cell_width);
 
   std::vector<RectangularRegion> regions = {
       region_1, region_2, region_3,  region_4,  region_5,  region_6, region_7,

--- a/src/rectangular_region.cc
+++ b/src/rectangular_region.cc
@@ -1,5 +1,6 @@
 #include "rectangular_region.h"
 
+#include <cmath>
 #include <ranges>
 
 #include "point.h"
@@ -16,6 +17,20 @@ RectangularRegion::RectangularRegion(const Material& material,
       ymax_(ymax),
       nx_(nx),
       ny_(ny) {
+  CreateCells();
+}
+
+RectangularRegion::RectangularRegion(const Material& material,
+                                     const double xmin, const double xmax,
+                                     const double ymin, const double ymax,
+                                     const double target_delta)
+    : material_(material),
+      xmin_(xmin),
+      xmax_(xmax),
+      ymin_(ymin),
+      ymax_(ymax),
+      nx_(std::ceil((xmax - xmin) / target_delta)),
+      ny_(std::ceil((ymax - ymin) / target_delta)) {
   CreateCells();
 }
 


### PR DESCRIPTION
## Summary of changes
<!--- In one or more sentences, describe the PR you are submitting. -->
Adds overloaded constructor to take a base cell width and approximates the number of _square_ cells that can be created using that value. This allows for more-effective grid-convergence studies down the line because we only need to change one parameter.

The problem domain has been adjusted to take this constructor, and a global value has been set to ensure a uniform grid is created.

<img width="945" height="863" alt="image" src="https://github.com/user-attachments/assets/ea1a11cc-30aa-423b-bc3e-5ee51345da86" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


## Associated Developers
<!--- Please mention any developers who should be alerted of this PR. -->

- Dev: @ElijahCapps 


## Checklist for Reviewers

Reviewers should use [this link](https://arfc.github.io/manual/guides/pull_requests) to get to the
Review Checklist before they begin their review.
